### PR TITLE
Fix cli command to enter license key

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ contracts section (https://www.group-office.com/account#account/contracts) if yo
 the professional version. This can be done via the browser GUI in the main menu -> register or via CLI:
 
 ```
-docker compose exec -u www-data php ./www/cli.php core/System/setLicense --key=<YOURKEY>
+docker compose exec -u www-data groupoffice php /usr/local/share/groupoffice/cli.php core/System/setLicense --key=<YOURKEY>
 ```
 
 Navigate in the folder of this repo and checkout another branch:


### PR DESCRIPTION
Hi,

the current command is missing a container name / service name where to run the php command, so it throws an error: 

`service "php" is not running`

Also the path of the `cli.php` does not seem to be correct anymore

`Could not open input file: ./www/cli.php`

This patch fixes both...

Best regards
Daniel