### PR TITLE
Fix for #26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,19 +64,12 @@ VOLUME /etc/ssl/groupoffice
 COPY ./etc/php.ini $PHP_INI_DIR
 
 #configure apache
-ADD ./etc/apache2/sites-available/000-default.conf $APACHE_CONFDIR/sites-available/000-default.conf
+COPY ./etc/apache2/sites-available/000-default.conf $APACHE_CONFDIR/sites-available/000-default.conf
 
-RUN mkdir -p /etc/groupoffice/multi_instance && chown -R www-data:www-data /etc/groupoffice
+#default database connection config
+COPY ./etc/groupoffice/docker-config.php.tpl /usr/local/share/groupoffice-docker-config.php.tpl
 #default group-office config
-ADD ./etc/groupoffice/docker-config.php.tpl /usr/local/share/groupoffice-docker-config.php.tpl
-ADD ./etc/groupoffice/config.php /etc/groupoffice/config.php
-
-#For persistant configuration
-VOLUME /etc/groupoffice
-
-RUN mkdir -p /var/lib/groupoffice/multi_instance && chown -R www-data:www-data /var/lib/groupoffice
-#Group-Office data:
-VOLUME /var/lib/groupoffice
+COPY ./etc/groupoffice/config.php /usr/local/share/groupoffice-config.php
 
 COPY docker-go-entrypoint.sh /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,10 +82,19 @@ COPY ./etc/php.ini $PHP_INI_DIR
 #configure apache
 COPY ./etc/apache2/sites-available/000-default.conf $APACHE_CONFDIR/sites-available/000-default.conf
 
-#default database connection config
-COPY ./etc/groupoffice/docker-config.php.tpl /usr/local/share/groupoffice-docker-config.php.tpl
 #default group-office config
+COPY ./etc/groupoffice/docker-config.php.tpl /usr/local/share/groupoffice-docker-config.php.tpl
 COPY ./etc/groupoffice/config.php /usr/local/share/groupoffice-config.php
+
+RUN mkdir -p /etc/groupoffice/multi_instance && chown -R www-data:www-data /etc/groupoffice
+RUN cp -a /usr/local/share/groupoffice-config.php /etc/groupoffice/config.php
+
+#For persistant configuration
+VOLUME /etc/groupoffice
+
+RUN mkdir -p /var/lib/groupoffice/multi_instance && chown -R www-data:www-data /var/lib/groupoffice
+#Group-Office data:
+VOLUME /var/lib/groupoffice
 
 COPY docker-go-entrypoint.sh /usr/local/bin/
 

--- a/docker-go-entrypoint.sh
+++ b/docker-go-entrypoint.sh
@@ -1,13 +1,24 @@
 #!/bin/sh
 set -e
 
+if [ ! -d /etc/groupoffice/multi_instance ]; then
+    mkdir -p /etc/groupoffice/multi_instance && chown -R www-data:www-data /etc/groupoffice
+fi
+
+if [ ! -d /var/lib/groupoffice/multi_instance ]; then
+    mkdir -p /var/lib/groupoffice/multi_instance && chown -R www-data:www-data /var/lib/groupoffice
+fi
+
+if [ ! -f /etc/groupoffice/config.php ]; then
+    cp /usr/local/share/groupoffice-config.php /etc/groupoffice/config.php
+fi
+
 cp /usr/local/share/groupoffice-docker-config.php.tpl /etc/groupoffice/docker-config.php
 
 sed -i 's/{dbHost}/'${MYSQL_HOST}'/' /etc/groupoffice/docker-config.php
 sed -i 's/{dbName}/'${MYSQL_DATABASE}'/' /etc/groupoffice/docker-config.php
 sed -i 's/{dbUser}/'${MYSQL_USER}'/' /etc/groupoffice/docker-config.php
 sed -i 's/{dbPass}/'${MYSQL_PASSWORD}'/' /etc/groupoffice/docker-config.php
-
 
 #call original entry point
 docker-php-entrypoint "$@"


### PR DESCRIPTION
Hi Merijn,

this is a possible fix for #26 ...

If I understand this correctly, by using VOLUME inside the Dockerfile the data inside are reserverd inside the image as a volume and when you start the container using a volume mount the data are copied there. But when you create a bind-mount instead, it is empty when you start the containers for the first time.

In this fix I removed the creation of the volumes and only copied the needed files inside the image. The creation is now moved to the docker entrypoint, so if the files or folders are missing, they are created/copied, otherwise ignored. This way it doesn't matter what is being used as a data mount.

Best regards
Daniel